### PR TITLE
fix(lyform): validation when is pure value

### DIFF
--- a/packages/lyform/lib/src/ly_input/ly_input.dart
+++ b/packages/lyform/lib/src/ly_input/ly_input.dart
@@ -35,7 +35,7 @@ class LyInput<T> extends Cubit<LyInputState<T>> {
   final LyValidationType validationType;
   final String? debugName;
 
-  bool get isPure => state.pureValue == state.value;
+  bool get isPure => state.pureValue == state.value && isValid;
   bool get isValid => state.error == null;
   bool get isInvalid => state.error != null;
 


### PR DESCRIPTION
When a pure value is validated in the form, it must indicate an invalidity status depending on the Validator used.