### PR TITLE
fix(lyform):  validation when the form is pure value state

### DIFF
--- a/packages/flutter_lyform/example/lib/main.dart
+++ b/packages/flutter_lyform/example/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:example/profile_form/profile_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-Future<void> main() async {
+void main() {
   Bloc.observer = AppBlocObserver();
   runApp(const App());
 }

--- a/packages/flutter_lyform/example/lib/profile_form/profile_page.dart
+++ b/packages/flutter_lyform/example/lib/profile_form/profile_page.dart
@@ -1,5 +1,6 @@
 import 'package:example/profile_form/profile_form.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_lyform/flutter_lyform.dart';
 
@@ -87,8 +88,12 @@ class ProfileView extends StatelessWidget {
               builder: (context, state) {
                 final bloc = context.read<ProfileForm>().age;
                 return TextField(
-                  onChanged: (value) => bloc.dirty(int.parse(value)),
+                  onChanged: (value) =>
+                      bloc.dirty(value.isEmpty ? 0 : int.parse(value)),
                   keyboardType: TextInputType.number,
+                  inputFormatters: [
+                    FilteringTextInputFormatter.digitsOnly,
+                  ],
                   decoration: InputDecoration(
                     hintText: 'Age',
                     errorText: state.error,
@@ -99,6 +104,11 @@ class ProfileView extends StatelessWidget {
             const SizedBox(height: 16),
             LyFormBuilder<ProfileForm>(
               bloc: context.read<ProfileForm>(),
+              onPure: () => const MaterialButton(
+                color: Colors.blueGrey,
+                onPressed: null,
+                child: Text('Save Profile'),
+              ),
               onLoading: () => const Center(
                 child: CircularProgressIndicator(),
               ),

--- a/packages/flutter_lyform/example/pubspec.yaml
+++ b/packages/flutter_lyform/example/pubspec.yaml
@@ -12,10 +12,13 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.3
-  flutter_lyform: ^0.13.0+1
-  lyform_validators: ^0.13.0+1
+  flutter_lyform:
+    path: ../../flutter_lyform
+  lyform_validators:
+    path: ../../lyform_validators
+
 dev_dependencies:
-  lint: ^1.10.0
+  lint: ^2.2.0
 
 flutter:
   uses-material-design: true

--- a/packages/flutter_lyform/example/pubspec.yaml
+++ b/packages/flutter_lyform/example/pubspec.yaml
@@ -5,14 +5,15 @@ publish_to: "none"
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.1 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.1.1
-  flutter_lyform: ^0.13.0
-  lyform_validators: ^0.13.0
+  flutter_bloc: ^8.1.3
+  flutter_lyform: ^0.13.0+1
+  lyform_validators: ^0.13.0+1
 dev_dependencies:
   lint: ^1.10.0
 

--- a/packages/flutter_lyform/lib/flutter_lyform.dart
+++ b/packages/flutter_lyform/lib/flutter_lyform.dart
@@ -1,4 +1,3 @@
-library flutter_lyform;
 
 export 'package:lyform/lyform.dart';
 

--- a/packages/flutter_lyform/pubspec.yaml
+++ b/packages/flutter_lyform/pubspec.yaml
@@ -5,15 +5,15 @@ homepage: https://github.com/lynotofficial/lynot-dart-flutter
 repository: https://github.com/lynotofficial/lynot-dart-flutter/tree/master/packages/flutter_lyform
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=3.0.0 <4.0.0"
+  flutter: ">=3.10.0"
 
 dependencies:
-  bloc: ^8.1.0
+  bloc: ^8.1.2
   flutter:
     sdk: flutter
-  flutter_bloc: ^8.1.1
-  lyform: ^0.13.0
+  flutter_bloc: ^8.1.3
+  lyform: ^0.13.0+1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/flutter_lyform/pubspec.yaml
+++ b/packages/flutter_lyform/pubspec.yaml
@@ -4,8 +4,6 @@ version: 0.13.0+1
 homepage: https://github.com/lynotofficial/lynot-dart-flutter
 repository: https://github.com/lynotofficial/lynot-dart-flutter/tree/master/packages/flutter_lyform
 
-publish_to: "none"
-
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.0"
@@ -15,9 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.3
-  # lyform: ^0.13.0+1
-  lyform: 
-    path: ../lyform
+  lyform: ^0.13.0+1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/flutter_lyform/pubspec.yaml
+++ b/packages/flutter_lyform/pubspec.yaml
@@ -4,6 +4,8 @@ version: 0.13.0+1
 homepage: https://github.com/lynotofficial/lynot-dart-flutter
 repository: https://github.com/lynotofficial/lynot-dart-flutter/tree/master/packages/flutter_lyform
 
+publish_to: "none"
+
 environment:
   sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.10.0"
@@ -13,9 +15,11 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.1.3
-  lyform: ^0.13.0+1
+  # lyform: ^0.13.0+1
+  lyform: 
+    path: ../lyform
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.10.0
-  mocktail: ^0.3.0
+  lint: ^2.2.0
+  mocktail: ^1.0.1

--- a/packages/flutter_riverform/example/riverform_login/pubspec.yaml
+++ b/packages/flutter_riverform/example/riverform_login/pubspec.yaml
@@ -6,21 +6,21 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.6
   flutter_riverform: ^0.1.0
-  flutter_riverpod: ^2.1.1
+  flutter_riverpod: ^2.4.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^2.0.0
+  flutter_lints: ^2.0.3
 
 flutter:
   uses-material-design: true

--- a/packages/flutter_riverform/lib/flutter_riverform.dart
+++ b/packages/flutter_riverform/lib/flutter_riverform.dart
@@ -1,4 +1,3 @@
-library flutter_riverform;
 
 export 'package:riverform/riverform.dart';
 

--- a/packages/flutter_riverform/lib/src/riverform_scope.dart
+++ b/packages/flutter_riverform/lib/src/riverform_scope.dart
@@ -68,7 +68,7 @@ class RiverformScope extends ConsumerWidget {
         for (final input in form.inputs)
           input.initialValueProvider.overrideWithProvider(
             (argument) => StateProvider((ref) => initialValues[input.id]),
-          )
+          ),
       ],
       child: RiverformProvider(
         form: form,

--- a/packages/flutter_riverform/pubspec.yaml
+++ b/packages/flutter_riverform/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  lint: ^1.10.0
+  lint: ^2.2.0
 
 flutter:

--- a/packages/flutter_riverform/pubspec.yaml
+++ b/packages/flutter_riverform/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_riverpod: ^2.1.1
+  flutter_riverpod: ^2.4.8
   riverform: ^0.1.0
 dev_dependencies:
   flutter_test:

--- a/packages/lyform/lib/lyform.dart
+++ b/packages/lyform/lib/lyform.dart
@@ -1,4 +1,2 @@
-library lyform;
-
 export 'src/ly_form/ly_form.dart';
 export 'src/ly_input/ly_input.dart';

--- a/packages/lyform/lib/src/ly_form/ly_form.dart
+++ b/packages/lyform/lib/src/ly_form/ly_form.dart
@@ -183,6 +183,8 @@ abstract class LyForm<D, E> extends Bloc<LyFormEvent, LyFormState<D, E>>
     return _inputs.every((input) => input.isValid);
   }
 
+  bool isInvalid() => !isValid();
+
   /// Are every input Pure?
   bool isPure() {
     return _inputs.every((input) => input.isPure);
@@ -322,8 +324,7 @@ abstract class LyForm<D, E> extends Bloc<LyFormEvent, LyFormState<D, E>>
     LyInput<dynamic> Function(
       LyInput<dynamic> value,
       LyInput<dynamic> element,
-    )
-        combine,
+    ) combine,
   ) =>
       _inputs.reduce(combine);
 

--- a/packages/lyform/lib/src/ly_input/ly_input.dart
+++ b/packages/lyform/lib/src/ly_input/ly_input.dart
@@ -52,7 +52,7 @@ class LyInput<T> extends Bloc<LyInputEvent<T>, LyInputState<T>> {
             debugName: debugName,
           ),
         );
-        if (validationType == LyValidationType.always) {
+        if (validationType != LyValidationType.none) {
           validate();
         }
         onPostDirty?.call(this, event.value);
@@ -122,7 +122,14 @@ class LyInput<T> extends Bloc<LyInputEvent<T>, LyInputState<T>> {
   final LyValidationType validationType;
   final String? debugName;
 
-  bool get isValid => validator?.call(value) == null;
+  bool get isValid {
+    if (validationType.isAlways || (!isPure && validationType.isExplicit)) {
+      return validator?.call(value) == null;
+    }
+
+    return true;
+  }
+
   bool get isInvalid => !isValid;
   bool get isPure => pureValue == value;
 

--- a/packages/lyform/lib/src/ly_input/ly_input.dart
+++ b/packages/lyform/lib/src/ly_input/ly_input.dart
@@ -122,7 +122,7 @@ class LyInput<T> extends Bloc<LyInputEvent<T>, LyInputState<T>> {
   final LyValidationType validationType;
   final String? debugName;
 
-  bool get isValid => isPure || (error?.isEmpty ?? true);
+  bool get isValid => validator?.call(value) == null;
   bool get isInvalid => !isValid;
   bool get isPure => pureValue == value;
 

--- a/packages/lyform/lib/src/ly_input/ly_validation_type.dart
+++ b/packages/lyform/lib/src/ly_input/ly_validation_type.dart
@@ -1,7 +1,16 @@
 part of 'ly_input.dart';
 
 enum LyValidationType {
+  /// Not validate the field
   none,
+
+  /// Only validate the field when is drity
   explicit,
-  always,
+
+  /// Always validate the field
+  always;
+
+  bool get isNone => this == none;
+  bool get isExplicit => this == explicit;
+  bool get isAlways => this == always;
 }

--- a/packages/lyform/pubspec.yaml
+++ b/packages/lyform/pubspec.yaml
@@ -8,13 +8,13 @@ environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  bloc: ^8.1.0
-  bloc_concurrency: ^0.2.0
-  collection: ^1.16.0
+  bloc: ^8.1.2
+  bloc_concurrency: ^0.2.2
+  collection: ^1.18.0
   equatable: ^2.0.5
 
 dev_dependencies:
-  bloc_test: ^9.1.0
+  bloc_test: ^9.1.5
   lint: ^1.10.0
   mocktail: ^0.3.0
-  test: ^1.21.4
+  test: ^1.24.9

--- a/packages/lyform/pubspec.yaml
+++ b/packages/lyform/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/lynotofficial/lynot-dart-flutter
 repository: https://github.com/lynotofficial/lynot-dart-flutter/tree/master/packages/lyform
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   bloc: ^8.1.2
@@ -15,6 +15,6 @@ dependencies:
 
 dev_dependencies:
   bloc_test: ^9.1.5
-  lint: ^1.10.0
-  mocktail: ^0.3.0
+  lint: ^2.2.0
+  mocktail: ^1.0.1
   test: ^1.24.9

--- a/packages/lyform/test/mocks/mock_forms.dart
+++ b/packages/lyform/test/mocks/mock_forms.dart
@@ -49,7 +49,10 @@ class TestForm extends LyForm<String, String> {
 
 class TestPureForm extends LyForm<String, String> {
   TestPureForm() {
-    addInputs([name]);
+    addInputs([
+      name,
+      lastname,
+    ]);
   }
 
   final name = LyInput<String>(
@@ -57,6 +60,13 @@ class TestPureForm extends LyForm<String, String> {
     validationType: LyValidationType.always,
     validator: const LyStringRequired('Invalid name.'),
     debugName: 'name',
+  );
+
+  final lastname = LyInput<String>(
+    pureValue: 'unknow',
+    validationType: LyValidationType.explicit,
+    validator: const LyStringRequired('Invalid lastname.'),
+    debugName: 'lastname',
   );
 
   @override

--- a/packages/lyform/test/mocks/mock_forms.dart
+++ b/packages/lyform/test/mocks/mock_forms.dart
@@ -47,6 +47,25 @@ class TestForm extends LyForm<String, String> {
   }
 }
 
+class TestPureForm extends LyForm<String, String> {
+  TestPureForm() {
+    addInputs([name]);
+  }
+
+  final name = LyInput<String>(
+    pureValue: 'unknow',
+    validationType: LyValidationType.always,
+    validator: const LyStringRequired('Invalid name.'),
+    debugName: 'name',
+  );
+
+  @override
+  Stream<LyFormState<String, String>> onSubmit() async* {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    yield success('Name save success!');
+  }
+}
+
 class MyBlocObserver extends BlocObserver {
   @override
   void onTransition(Bloc bloc, Transition transition) {

--- a/packages/lyform/test/src/ly_form/ly_form_test.dart
+++ b/packages/lyform/test/src/ly_form/ly_form_test.dart
@@ -68,6 +68,109 @@ void main() {
     );
 
     blocTest<TestForm, LyFormState>(
+      'check that form is "pure" and "invalid" without make any cahnge in the inputs',
+      build: () => TestForm(),
+      wait: const Duration(seconds: 1),
+      expect: () => [
+        const LyFormPureState<String, String>([
+          LyInputState(
+            value: '',
+            lastNotNullValue: '',
+            pureValue: '',
+            debugName: 'name',
+          ),
+        ]),
+      ],
+      verify: (form) {
+        expect(form.isPure(), isTrue);
+        expect(form.isInvalid(), isTrue);
+      },
+    );
+
+    blocTest<TestPureForm, LyFormState>(
+      'check that form is "pure" and "valid" without make any cahnge in the inputs',
+      build: () => TestPureForm(),
+      wait: const Duration(seconds: 1),
+      expect: () => [
+        const LyFormPureState<String, String>([
+          LyInputState(
+            value: 'unknow',
+            lastNotNullValue: 'unknow',
+            pureValue: 'unknow',
+            debugName: 'name',
+          ),
+        ]),
+      ],
+      verify: (form) {
+        expect(form.isPure(), isTrue);
+        expect(form.isValid(), isTrue);
+      },
+    );
+
+    blocTest<TestForm, LyFormState>(
+      'check that form is a "pure and invalid form" when make invalid change a input',
+      build: () => TestForm(),
+      act: (form) {
+        form.name.dirty('007');
+      },
+      wait: const Duration(seconds: 1),
+      expect: () => [
+        const LyFormPureState<String, String>([
+          LyInputState(
+            value: '',
+            lastNotNullValue: '',
+            pureValue: '',
+            debugName: 'name',
+          ),
+        ]),
+        const LyFormInvalidState<String, String>([
+          LyInputState(
+            value: '007',
+            lastNotNullValue: '007',
+            pureValue: '',
+            debugName: 'name',
+            error: 'Invalid name.',
+          ),
+        ]),
+      ],
+      verify: (form) {
+        expect(form.isPure(), isFalse);
+        expect(form.isValid(), isFalse);
+      },
+    );
+
+    blocTest<TestForm, LyFormState>(
+      'check that form is a "pure and valid form" when make valid change a input',
+      build: () => TestForm(),
+      act: (form) {
+        form.name.dirty('Laura');
+      },
+      wait: const Duration(seconds: 1),
+      expect: () => [
+        const LyFormPureState<String, String>([
+          LyInputState(
+            value: '',
+            lastNotNullValue: '',
+            pureValue: '',
+            debugName: 'name',
+          ),
+        ]),
+        const LyFormValidState<String, String>([
+          LyInputState(
+            value: 'Laura',
+            lastNotNullValue: 'Laura',
+            pureValue: '',
+            debugName: 'name',
+          ),
+        ]),
+      ],
+      verify: (form) {
+        expect(form.isPure(), isFalse);
+        expect(form.isValid(), isTrue);
+      },
+    );
+
+    blocTest<TestForm, LyFormState>(
       'check that add one input in the index 1',
       build: () => TestForm(),
       act: (form) => form.addInput(1, lyInputAge),
@@ -88,6 +191,10 @@ void main() {
           ),
         ]),
       ],
+      verify: (form) {
+        expect(form.isPure(), isTrue);
+        expect(form.isValid(), isFalse);
+      },
     );
 
     blocTest<TestForm, LyFormState>(

--- a/packages/lyform/test/src/ly_form/ly_form_test.dart
+++ b/packages/lyform/test/src/ly_form/ly_form_test.dart
@@ -99,6 +99,12 @@ void main() {
             pureValue: 'unknow',
             debugName: 'name',
           ),
+          LyInputState(
+            value: 'unknow',
+            lastNotNullValue: 'unknow',
+            pureValue: 'unknow',
+            debugName: 'lastname',
+          ),
         ]),
       ],
       verify: (form) {
@@ -139,9 +145,9 @@ void main() {
       },
     );
 
-    blocTest<TestForm, LyFormState>(
+    blocTest<TestPureForm, LyFormState>(
       'check that form is a "pure and valid form" when make valid change a input',
-      build: () => TestForm(),
+      build: () => TestPureForm(),
       act: (form) {
         form.name.dirty('Laura');
       },
@@ -149,18 +155,30 @@ void main() {
       expect: () => [
         const LyFormPureState<String, String>([
           LyInputState(
-            value: '',
-            lastNotNullValue: '',
-            pureValue: '',
+            value: 'unknow',
+            lastNotNullValue: 'unknow',
+            pureValue: 'unknow',
             debugName: 'name',
+          ),
+          LyInputState(
+            value: 'unknow',
+            lastNotNullValue: 'unknow',
+            pureValue: 'unknow',
+            debugName: 'lastname',
           ),
         ]),
         const LyFormValidState<String, String>([
           LyInputState(
             value: 'Laura',
             lastNotNullValue: 'Laura',
-            pureValue: '',
+            pureValue: 'unknow',
             debugName: 'name',
+          ),
+          LyInputState(
+            value: 'unknow',
+            lastNotNullValue: 'unknow',
+            pureValue: 'unknow',
+            debugName: 'lastname',
           ),
         ]),
       ],

--- a/packages/lyform/test/src/ly_form/ly_form_test.dart
+++ b/packages/lyform/test/src/ly_form/ly_form_test.dart
@@ -119,7 +119,7 @@ void main() {
             pureValue: '',
             debugName: 'name',
           ),
-        ])
+        ]),
       ],
     );
 
@@ -163,7 +163,7 @@ void main() {
             pureValue: '',
             debugName: 'name',
           ),
-        ])
+        ]),
       ],
     );
 
@@ -182,7 +182,7 @@ void main() {
             lastNotNullValue: 'ly',
             pureValue: '',
             debugName: 'name',
-          )
+          ),
         ]),
         LyFormValidState<String, String>([
           LyInputState(
@@ -202,7 +202,7 @@ void main() {
               debugName: 'name',
             ),
           ],
-        )
+        ),
       ],
     );
 

--- a/packages/lyform/test/src/ly_input/ly_input_test.dart
+++ b/packages/lyform/test/src/ly_input/ly_input_test.dart
@@ -1,8 +1,12 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:lyform/lyform.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../../mocks/mock_forms.dart';
+
+class MockLyInputBloc<T> extends MockBloc<LyInputEvent<T>, LyInputState<T>>
+    implements LyInput<T> {}
 
 void main() {
   blocTest<LyInput<String>, LyInputState<String>>(
@@ -160,6 +164,111 @@ void main() {
     ],
     verify: (input) {
       expect(input.pureValue, equals('ly'));
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `none`',
+    build: () => LyInput<String>(
+      pureValue: '',
+      validationType: LyValidationType.none,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    verify: (input) {
+      expect(input.pureValue, equals(''));
+      expect(input.isValid, isTrue);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `none` and call drity',
+    build: () => LyInput<String>(
+      pureValue: '',
+      validationType: LyValidationType.none,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    act: (input) => input.dirty('ly'),
+    expect: () => [
+      const LyInputState(
+        value: 'ly',
+        lastNotNullValue: 'ly',
+        pureValue: '',
+      ),
+    ],
+    verify: (input) {
+      expect(input.value, equals('ly'));
+      expect(input.isValid, isTrue);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `explicit`',
+    build: () => LyInput<String>(
+      pureValue: '',
+      validationType: LyValidationType.explicit,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    verify: (input) {
+      expect(input.pureValue, equals(''));
+      expect(input.isValid, isTrue);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `explicit` and call dirty',
+    build: () => LyInput<String>(
+      pureValue: '',
+      validationType: LyValidationType.explicit,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    act: (input) => input.dirty('ly'),
+    expect: () => [
+      const LyInputState(
+        value: 'ly',
+        lastNotNullValue: 'ly',
+        pureValue: '',
+      ),
+    ],
+    verify: (input) {
+      expect(input.value, equals('ly'));
+      expect(input.isValid, isTrue);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `always`',
+    build: () => MockLyInputBloc<String>(
+      pureValue: '',
+      validationType: LyValidationType.always,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    verify: (input) {
+      expect(input.pureValue, equals(''));
+      expect(input.value, equals(''));
+      expect(input.isValid, isFalse);
+
+      verify(() => input.validate()).called(1);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `always` and call dirty',
+    build: () => LyInput<String>(
+      pureValue: '',
+      validationType: LyValidationType.always,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    act: (input) => input.dirty('ly'),
+    expect: () => [
+      const LyInputState(
+        value: 'ly',
+        lastNotNullValue: 'ly',
+        pureValue: '',
+      ),
+    ],
+    verify: (input) {
+      expect(input.value, equals('ly'));
+      expect(input.isValid, isTrue);
     },
   );
 }

--- a/packages/lyform/test/src/ly_input/ly_input_test.dart
+++ b/packages/lyform/test/src/ly_input/ly_input_test.dart
@@ -127,7 +127,7 @@ void main() {
         value: 'ly',
         lastNotNullValue: 'ly',
         pureValue: 'ly',
-      )
+      ),
     ],
     verify: (input) {
       expect(input.pureValue, equals('ly'));

--- a/packages/lyform/test/src/ly_input/ly_input_test.dart
+++ b/packages/lyform/test/src/ly_input/ly_input_test.dart
@@ -59,7 +59,7 @@ void main() {
   );
 
   blocTest<LyInput<String>, LyInputState<String>>(
-    'check that isValid is true when isPure is true',
+    'check that isValid is "false" when validate the invalid pure value',
     build: () => LyInput<String>(
       pureValue: '',
       validationType: LyValidationType.always,
@@ -67,20 +67,49 @@ void main() {
     ),
     wait: const Duration(seconds: 1),
     verify: (input) {
+      expect(input.isPure, isTrue);
+      expect(input.isValid, isFalse);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check that isValid is "true" when validate the valid pure value',
+    build: () => LyInput<String>(
+      pureValue: 'hello',
+      validationType: LyValidationType.always,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    wait: const Duration(seconds: 1),
+    verify: (input) {
+      expect(input.isPure, isTrue);
       expect(input.isValid, isTrue);
     },
   );
 
   blocTest<LyInput<String>, LyInputState<String>>(
-    'check that isInvalid is false when isPure is true',
+    'check that isInvalid is "true" when validate the invalid pure value',
     build: () => LyInput<String>(
       pureValue: '',
       validationType: LyValidationType.always,
       validator: const LyStringRequired('Is required.'),
     ),
     wait: const Duration(seconds: 1),
-    act: (bloc) => bloc.dirty(''),
     verify: (input) {
+      expect(input.isPure, isTrue);
+      expect(input.isInvalid, isTrue);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check that isInvalid is "false" when validate the valid pure value',
+    build: () => LyInput<String>(
+      pureValue: 'hello',
+      validationType: LyValidationType.always,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    wait: const Duration(seconds: 1),
+    verify: (input) {
+      expect(input.isPure, isTrue);
       expect(input.isInvalid, isFalse);
     },
   );

--- a/packages/lyform/test/src/ly_input/ly_input_test.dart
+++ b/packages/lyform/test/src/ly_input/ly_input_test.dart
@@ -1,12 +1,8 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:lyform/lyform.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
 import '../../mocks/mock_forms.dart';
-
-class MockLyInputBloc<T> extends MockBloc<LyInputEvent<T>, LyInputState<T>>
-    implements LyInput<T> {}
 
 void main() {
   blocTest<LyInput<String>, LyInputState<String>>(
@@ -236,8 +232,35 @@ void main() {
   );
 
   blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `explicit` and call dirty and is invalid',
+    build: () => LyInput<String>(
+      pureValue: 'dart',
+      validationType: LyValidationType.explicit,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    act: (input) => input.dirty(''),
+    expect: () => [
+      const LyInputState(
+        value: '',
+        pureValue: 'dart',
+        lastNotNullValue: '',
+      ),
+      const LyInputState(
+        value: '',
+        pureValue: 'dart',
+        lastNotNullValue: '',
+        error: 'Is required.',
+      ),
+    ],
+    verify: (input) {
+      expect(input.value, equals(''));
+      expect(input.isInvalid, isTrue);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
     'check state when validationType is `always`',
-    build: () => MockLyInputBloc<String>(
+    build: () => LyInput<String>(
       pureValue: '',
       validationType: LyValidationType.always,
       validator: const LyStringRequired('Is required.'),
@@ -246,8 +269,6 @@ void main() {
       expect(input.pureValue, equals(''));
       expect(input.value, equals(''));
       expect(input.isValid, isFalse);
-
-      verify(() => input.validate()).called(1);
     },
   );
 
@@ -269,6 +290,33 @@ void main() {
     verify: (input) {
       expect(input.value, equals('ly'));
       expect(input.isValid, isTrue);
+    },
+  );
+
+  blocTest<LyInput<String>, LyInputState<String>>(
+    'check state when validationType is `always` and call dirty and is invalid',
+    build: () => LyInput<String>(
+      pureValue: 'dart',
+      validationType: LyValidationType.always,
+      validator: const LyStringRequired('Is required.'),
+    ),
+    act: (input) => input.dirty(''),
+    expect: () => [
+      const LyInputState(
+        value: '',
+        pureValue: 'dart',
+        lastNotNullValue: '',
+      ),
+      const LyInputState(
+        value: '',
+        pureValue: 'dart',
+        lastNotNullValue: '',
+        error: 'Is required.',
+      ),
+    ],
+    verify: (input) {
+      expect(input.value, equals(''));
+      expect(input.isInvalid, isTrue);
     },
   );
 }

--- a/packages/lyform/test/src/ly_input/ly_input_validator_test.dart
+++ b/packages/lyform/test/src/ly_input/ly_input_validator_test.dart
@@ -89,8 +89,8 @@ void main() {
   group('LyListValidator', () {
     test('return null when one or more validators are valid', () {
       final lyListValidator = LyListValidator<String>([
-        lyStringRequired,
-        lyStringRequired,
+        lyStringRequired.call,
+        lyStringRequired.call,
       ]);
 
       expect(lyStringRequired(value), isNull);
@@ -106,9 +106,9 @@ void main() {
 
     test('return a message when one or more validators are invalid', () {
       final lyListValidator = LyListValidator<String>([
-        lyStringRequired,
-        LyEmptyValidator<String>(),
-        LyEmptyValidator<String>(),
+        lyStringRequired.call,
+        LyEmptyValidator<String>().call,
+        LyEmptyValidator<String>().call,
       ]);
 
       expect(lyStringRequired(emptyValue), equals(message));

--- a/packages/lyform_validators/lib/lyform_validators.dart
+++ b/packages/lyform_validators/lib/lyform_validators.dart
@@ -1,4 +1,3 @@
-library lyform_validators;
 
 export 'src/general_validators.dart';
 export 'src/int_validators.dart';

--- a/packages/lyform_validators/lib/src/int_validators.dart
+++ b/packages/lyform_validators/lib/src/int_validators.dart
@@ -37,6 +37,7 @@ class LyIntGreaterThan extends LyValidator<int> {
 /// final result = validation(10);
 /// print(result); // Must be greater than or equal to 11
 /// ```
+/// {@endtemplate}
 class LyIntGreaterEqualThan extends LyValidator<int> {
   /// {@macro int_greater_equal_than_validators}
   LyIntGreaterEqualThan(this.limit, String message) : super(message);
@@ -60,6 +61,7 @@ class LyIntGreaterEqualThan extends LyValidator<int> {
 /// final result = validation(15);
 /// print(result); // Must be less than 11
 /// ```
+/// {@endtemplate}
 class LyIntLesserThan extends LyValidator<int> {
   /// {@macro int_less_than_validators}
   LyIntLesserThan(this.limit, String message) : super(message);
@@ -83,6 +85,7 @@ class LyIntLesserThan extends LyValidator<int> {
 /// final result = validation(10);
 /// print(result); // Must be less than or equal to 8
 /// ```
+/// {@endtemplate}
 class LyIntLesserEquealThan extends LyValidator<int> {
   /// {@macro int_less_equal_than_validators}
   LyIntLesserEquealThan(this.limit, String message) : super(message);
@@ -106,6 +109,7 @@ class LyIntLesserEquealThan extends LyValidator<int> {
 /// final result = validation(-1);
 /// print(result); // Must be non negative
 /// ```
+/// {@endtemplate}
 class LyIntNonNegative extends LyValidator<int> {
   /// {@macro int_non_negative_validators}
   LyIntNonNegative(super.message);

--- a/packages/lyform_validators/lib/src/nullable_string_validators.dart
+++ b/packages/lyform_validators/lib/src/nullable_string_validators.dart
@@ -130,6 +130,7 @@ class LyNullableStringContains extends LyValidator<String?> {
 /// final validator = LyNullableStringMatches('Invalid email', r'^[a-zA-Z0-9]*$');
 /// final result = validation('abc');
 /// print(result); // Invalid email
+/// ```
 /// {@endtemplate}
 class LyNullableStringMatches extends LyValidator<String?> {
   /// {@macro nullable_string_matches_validator}

--- a/packages/lyform_validators/lib/src/nullable_string_validators.dart
+++ b/packages/lyform_validators/lib/src/nullable_string_validators.dart
@@ -130,6 +130,7 @@ class LyNullableStringContains extends LyValidator<String?> {
 /// final validator = LyNullableStringMatches('Invalid email', r'^[a-zA-Z0-9]*$');
 /// final result = validation('abc');
 /// print(result); // Invalid email
+/// {@endtemplate}
 class LyNullableStringMatches extends LyValidator<String?> {
   /// {@macro nullable_string_matches_validator}
   LyNullableStringMatches(super.message, this.pattern);

--- a/packages/lyform_validators/pubspec.yaml
+++ b/packages/lyform_validators/pubspec.yaml
@@ -5,13 +5,13 @@ homepage: https://github.com/lynotofficial/lynot-dart-flutter
 repository: https://github.com/lynotofficial/lynot-dart-flutter/tree/master/packages/lyform_validators
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  lyform: ^0.13.0
+  lyform: ^0.13.0+1
   validators: ^3.0.0
 
 dev_dependencies:
   lint: ^1.10.0
   mocktail: ^0.3.0
-  test: ^1.21.4
+  test: ^1.24.9

--- a/packages/lyform_validators/pubspec.yaml
+++ b/packages/lyform_validators/pubspec.yaml
@@ -12,6 +12,6 @@ dependencies:
   validators: ^3.0.0
 
 dev_dependencies:
-  lint: ^1.10.0
-  mocktail: ^0.3.0
+  lint: ^2.2.0
+  mocktail: ^1.0.1
   test: ^1.24.9

--- a/packages/riverform/lib/src/form/riverform.dart
+++ b/packages/riverform/lib/src/form/riverform.dart
@@ -16,7 +16,7 @@ class Riverform {
         final allInputs = inputs;
         final inputsValues = {
           for (final input in allInputs)
-            input.id: ref.watch(input.provider(formId))
+            input.id: ref.watch(input.provider(formId)),
         };
 
         final values = inputsValues.values;

--- a/packages/riverform/pubspec.yaml
+++ b/packages/riverform/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
   sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
-  async: ^2.9.0
+  async: ^2.11.0
   equatable: ^2.0.5
-  riverpod: ^2.1.1
+  riverpod: ^2.4.8
 
 dev_dependencies:
   lint: ^1.10.0
-  test: ^1.21.4
+  test: ^1.24.9

--- a/packages/riverform/pubspec.yaml
+++ b/packages/riverform/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/lynot/lynot-dart-flutter
 repository: https://github.com/lynot/lynot-dart-flutter/tree/master/packages/riverform
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   async: ^2.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,9 @@
+name: workspace
+description: required by melos ^3.0.0
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dev_dependencies:
+  lockpick: ^0.0.4
+  melos: ^3.2.0


### PR DESCRIPTION
The major change is apply in `isValid` getter, where is it called the `validator` to check in the momento if valid or not the input.

Before:
```dart
bool get isValid => isPure || (error?.isEmpty ?? true);
```

After:
```dart
  bool get isValid {
    if (validationType.isAlways || (!isPure && validationType.isExplicit)) {
      return validator?.call(value) == null;
    }

    return true;
  }
 ```

Other changes:
- [update all dependencies to user sdk >= 3.0.0](https://github.com/lynot/lynot-dart-flutter/commit/786da110da9d99bf900723523bb555c25e2ab6d8)
- add some test to check the new changes